### PR TITLE
[to test] Read included and excluded way tags from args

### DIFF
--- a/src/main/java/osmparser/Main.java
+++ b/src/main/java/osmparser/Main.java
@@ -2,10 +2,11 @@ package osmparser;
 
 import org.apache.commons.cli.*;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 public class Main {
     private static String PROGRAM_NAME = "osmparser";
@@ -19,26 +20,60 @@ public class Main {
         try {
             cmd = parser.parse(options, args);
         } catch (ParseException ex) {
-            System.out.println(ex.getMessage());
+            error(ex.getMessage());
             new HelpFormatter().printHelp(PROGRAM_NAME, options);
             System.exit(EXIT_FAIL);
         }
 
-        boolean verbose = cmd.hasOption("verbose");
+        boolean notQuiet = cmd.hasOption("quiet");
 
         String[] files = cmd.getOptionValues("files");
-        if (verbose) {
-            System.out.println("Parsing files: " + Arrays.asList(files));
+        if (notQuiet) {
+            info("Parsing files: " + Arrays.asList(files));
+        }
+
+        String[] includeWayProps = cmd.getOptionValues("includeWays");
+        String[] excludeWayProps = cmd.getOptionValues("excludeWays");
+
+        WayTag[] includedTags = parseWayTagsFromOptions(includeWayProps);
+        WayTag[] excludedTags = parseWayTagsFromOptions(excludeWayProps);
+
+        if (notQuiet) {
+            info("Included tags: " + Arrays.asList(includedTags));
+            info("Excluded tags: " + Arrays.asList(excludedTags));
         }
 
         try {
-            new Osmparser(files, "graph.json").start();
+            createOsmparser(files, includedTags, excludedTags).start();
         } catch (RuntimeException ex) {
             if (!(ex.getCause() instanceof IOException)) {
                 throw ex;
             }
             System.out.println("Error while reading file: " + ex.getCause().getMessage());
         }
+    }
+
+    private static WayTag[] parseWayTagsFromOptions(String[] optionValues) {
+        if (optionValues == null || optionValues.length == 0) {
+            return new WayTag[0];
+        }
+
+        WayTag[] tags = new WayTag[optionValues.length];
+        for (int i = 0; i < tags.length; i++) {
+            // Split key=value pairs, skipping escaped \=
+            String[] tokens = optionValues[i].split("(?<!\\\\)=", 2);
+            WayTag tag = tokens.length == 1
+                ? new WayTag(tokens[0])
+                : new WayTag(tokens[0], tokens[1]);
+            tags[i] = tag;
+        }
+
+        return tags;
+    }
+
+    private static Osmparser createOsmparser(String[] files, WayTag[] includeWays, WayTag[] excludeWays) {
+        StreamingXmlGraphParser graphParser = new StreamingXmlGraphParser(includeWays, excludeWays);
+        return new Osmparser(files, "graph.json", graphParser);
     }
 
     private static Options createOptions() {
@@ -52,12 +87,39 @@ public class Main {
             .build();
         options.addOption(files);
 
-        Option verbose = Option.builder("v")
-            .longOpt("verbose")
-            .desc("print verbose output")
+        Option verbose = Option.builder("q")
+            .longOpt("quiet")
+            .desc("suppress console output")
             .build();
         options.addOption(verbose);
 
+        Option includeWays = Option.builder("i")
+            .longOpt("includeWays")
+            .desc("way tags to include")
+            .hasArgs()
+            .build();
+        options.addOption(includeWays);
+
+        Option excludeWays = Option.builder("e")
+            .longOpt("excludeWays")
+            .desc("way tags to exclude (overrides includeWay)")
+            .hasArgs()
+            .build();
+        options.addOption(excludeWays);
+
         return options;
+    }
+
+    // TODO: use a proper logger library
+    private static void info(String message) {
+        System.out.println(message);
+    }
+
+    private static void info(String fmt, Object... args) {
+        System.out.printf(fmt + "%n", args);
+    }
+
+    private static void error(String message) {
+        System.out.println(message);
     }
 }

--- a/src/main/java/osmparser/Osmparser.java
+++ b/src/main/java/osmparser/Osmparser.java
@@ -17,10 +17,6 @@ public class Osmparser {
     private final String outFile;
     private final GraphParser parser;
 
-    public Osmparser(String[] mapFiles, String outFile) {
-        this(mapFiles, outFile, new StreamingXmlGraphParser("highway"));
-    }
-
     public Osmparser(String[] mapFiles, String outFile, GraphParser graphParser) {
         this.mapFiles = mapFiles;
         this.outFile = outFile;

--- a/src/main/java/osmparser/WayTag.java
+++ b/src/main/java/osmparser/WayTag.java
@@ -1,0 +1,30 @@
+package osmparser;
+
+public class WayTag {
+    private final String tagKey;
+    private final String tagValue;
+
+    public WayTag(String tagKeyToMatch) {
+        this(tagKeyToMatch, null);
+    }
+
+    public WayTag(String tagKey, String tagValue) {
+        this.tagKey = tagKey;
+        this.tagValue = tagValue;
+    }
+
+    public String getTagKey() {
+        return tagKey;
+    }
+
+    public String getTagValue() {
+        return tagValue;
+    }
+
+    @Override
+    public String toString() {
+        return tagValue == null
+            ? String.format("WayTag{tagKey='%s'}", tagKey)
+            : String.format("WayTag{tagKey='%s', tagValue='%s'}", tagKey, tagValue);
+    }
+}


### PR DESCRIPTION
Add two new command line flags: `--includeWays` and `--excludeWays`. Include can
be used as a "if any of these match, include the tag" whereas exclude can be
used as a "if any of these match, do not include the tag". Shorthands are `-i` and
`-e`. Exclusion takes priority over inclusion.

Usage:

    osmparser -f map.osm -i highway railway=abandoned -e access=no access=private
    osmparser -f map.osm -i railway -e railway=abandoned

Commit also removes `--verbose` and adds `--quiet`. Proper logging should be added
next.

Closes #3.